### PR TITLE
Fixed error in c2004.csv

### DIFF
--- a/data/c2004.csv
+++ b/data/c2004.csv
@@ -1,5 +1,5 @@
 Pos,Name,Value
-1,Qatar
+1,Qatar,
 2,Luxembourg,$92400
 3,Liechtenstein,$89400
 4,Macau,$88700


### PR DESCRIPTION
On line 2, most packages such as Python Pandas and Julia Dataframes require a comma separator that separates each row into same number of columns for all rows. In this case, line 2 has only 2 columns which causes an issue with dataframes objects.